### PR TITLE
Ignore click event of pokeball behide appbar in pokemon info page

### DIFF
--- a/lib/screens/pokemon_info/widgets/info.dart
+++ b/lib/screens/pokemon_info/widgets/info.dart
@@ -297,15 +297,18 @@ class _PokemonOverallInfoState extends State<PokemonOverallInfo> with TickerProv
       Positioned(
         top: pokeTop,
         right: pokeRight,
-        child: AnimatedFade(
-          animation: cardScrollController,
-          child: AnimatedRotation(
-            animation: _rotateController,
-            child: Image.asset(
-              "assets/images/pokeball.png",
-              width: pokeSize,
-              height: pokeSize,
-              color: Colors.white.withOpacity(0.26),
+        child: IgnorePointer(
+          ignoring: true,
+          child: AnimatedFade(
+            animation: cardScrollController,
+            child: AnimatedRotation(
+              animation: _rotateController,
+              child: Image.asset(
+                "assets/images/pokeball.png",
+                width: pokeSize,
+                height: pokeSize,
+                color: Colors.white.withOpacity(0.26),
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
Simply wrapping the pokeball with IgnorePointer
Fix #19 