### PR TITLE
Fix FAB opening and closing

### DIFF
--- a/lib/screens/pokedex/pokedex.dart
+++ b/lib/screens/pokedex/pokedex.dart
@@ -157,9 +157,11 @@ class _PokedexState extends State<Pokedex> with SingleTickerProviderStateMixin {
           ),
         ],
         animation: _animation,
-        onPress: _animationController.isCompleted
-            ? _animationController.reverse
-            : _animationController.forward,
+        onPress: () {
+          _animationController.isCompleted
+              ? _animationController.reverse()
+              : _animationController.forward();
+        },
       ),
     );
   }


### PR DESCRIPTION
The FAB in the Pokedex page was opening the menu, but when clicked again, it didn't close the menu. This minor edit achieves the desired behaviour.